### PR TITLE
Fix gallery viewport detection for cross-browser compatibility

### DIFF
--- a/components/GallerySection.tsx
+++ b/components/GallerySection.tsx
@@ -156,7 +156,7 @@ export default function GallerySection({ paintings, onSelectPainting }: GalleryS
             variants={containerVariants}
             initial="hidden"
             whileInView="visible"
-            viewport={{ once: true, margin: '0px', amount: 0.1 }}
+            viewport={{ once: true, margin: '-100px', amount: 0.05 }}
             className="space-y-24 md:space-y-32 lg:space-y-40 mt-[200px]"
             >
             {paintings.map((painting, index) => {


### PR DESCRIPTION
## Summary
- Fixed gallery animations not triggering properly on non-iOS browsers
- Adjusted viewport detection settings from `amount: 0.1` to `amount: 0.05`
- Changed margin from `'0px'` to `'-100px'` for better cross-browser compatibility
- Maintains iOS Safari compatibility while fixing issues on other browsers

## Test plan
- [x] Tested gallery visibility and animations on local development server
- [x] Verified production build compiles successfully
- [x] Confirmed all paintings are visible and animations trigger properly
- [x] Maintained responsive design across different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)