### PR TITLE
Fix gallery viewport detection to restore cross-browser functionality

### DIFF
--- a/components/GallerySection.tsx
+++ b/components/GallerySection.tsx
@@ -156,7 +156,7 @@ export default function GallerySection({ paintings, onSelectPainting }: GalleryS
             variants={containerVariants}
             initial="hidden"
             whileInView="visible"
-            viewport={{ once: true, margin: '0px', amount: 0.1 }}
+            viewport={{ once: true, margin: '-100px', amount: 0.05 }}
             className="space-y-24 md:space-y-32 lg:space-y-40 mt-[200px]"
             >
             {paintings.map((painting, index) => {

--- a/components/GallerySection.tsx
+++ b/components/GallerySection.tsx
@@ -156,7 +156,7 @@ export default function GallerySection({ paintings, onSelectPainting }: GalleryS
             variants={containerVariants}
             initial="hidden"
             whileInView="visible"
-            viewport={{ once: true, margin: '-100px', amount: 0.05 }}
+            viewport={{ once: true, margin: '-200px' }}
             className="space-y-24 md:space-y-32 lg:space-y-40 mt-[200px]"
             >
             {paintings.map((painting, index) => {


### PR DESCRIPTION
## Summary
- Reverts gallery viewport detection settings that were causing display issues
- Fixes gallery not showing paintings on non-iOS browsers  
- Restores working behavior from commit 9ef7c8a

## Changes Made
- Changed viewport settings from `margin: '-100px', amount: 0.05` back to `margin: '-200px'`
- This fixes the animation trigger threshold that was preventing gallery display

## Root Cause
The recent iOS Safari compatibility fix made the viewport detection too sensitive, breaking gallery functionality across all other browsers.

## Test Plan
- [x] Gallery displays all 50 paintings
- [x] Painting modal opens when clicked
- [x] Cross-browser compatibility verified with Playwright
- [x] No functional regressions

🤖 Generated with [Claude Code](https://claude.ai/code)