### PR TITLE
Fix iOS Safari gallery viewport detection issue

### DIFF
--- a/components/GallerySection.tsx
+++ b/components/GallerySection.tsx
@@ -65,7 +65,7 @@ const statisticVariants = {
 
 export default function GallerySection({ paintings, onSelectPainting }: GallerySectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [viewportConfig, setViewportConfig] = useState({ once: true, margin: '-200px' });
+  const [viewportConfig, setViewportConfig] = useState<{ once: boolean; margin?: string; amount?: number }>({ once: true, margin: '-200px' });
   const [debugInfo, setDebugInfo] = useState('');
 
   // Detect iOS and configure viewport settings
@@ -83,7 +83,7 @@ export default function GallerySection({ paintings, onSelectPainting }: GalleryS
         once: true, 
         margin: '0px',
         amount: 0.05
-      } as any);
+      });
     } else {
       // Keep original settings for desktop
       setViewportConfig({ once: true, margin: '-200px' });


### PR DESCRIPTION
## Summary
- Fix iOS Safari gallery viewport detection that prevented paintings from appearing during scroll
- Add runtime iOS/Safari detection using user agent strings  
- Use iOS-specific viewport settings: `margin: '0px', amount: 0.05`
- Maintain desktop compatibility with original settings: `margin: '-200px'`
- Add temporary debug panel for testing iOS behavior

## Test plan
- [x] Build passes successfully
- [x] Desktop browsers work with original viewport settings
- [ ] Test on real iOS Safari device to verify paintings appear during scroll
- [ ] Remove debug panel after iOS issue is confirmed fixed

## Technical Details
This addresses intersection observer behavioral differences between iOS Safari and desktop browsers. The previous attempts using static compromise settings broke either iOS or desktop. This solution uses runtime detection to apply appropriate settings for each platform.

🤖 Generated with [Claude Code](https://claude.ai/code)