### PR TITLE
Remove year display below gallery frames

### DIFF
--- a/components/PaintingFrame.tsx
+++ b/components/PaintingFrame.tsx
@@ -197,17 +197,6 @@ export default function PaintingFrame({
 
         </div>
 
-        {/* Museum Label */}
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={isIntersecting ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: index * 0.1 + 0.3 }}
-          className="absolute -bottom-12 left-4 right-4 bg-gallery-50 border border-gallery-200 p-3 rounded-sm shadow-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-        >
-          <div className="text-center text-artist-brown text-sm font-medium">
-            {painting.year || 'Date unknown'}
-          </div>
-        </motion.div>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed the museum label that displayed the year below each painting frame
- Year information is still accessible on hover within the frame overlay
- Maintains clean gallery appearance while preserving contextual information

## Test plan
- [x] Build succeeds without errors
- [x] Year still appears on hover within frame
- [x] Museum label below frame is removed
- [x] Gallery layout remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)