### PR TITLE
Fix Android viewport jumping and title visibility issues

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,15 +20,28 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+  /* Prevent viewport jumping on Android */
+  height: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+
 body {
   font-family: var(--font-inter);
   background: #faf8f5;
   color: #5d4e37;
   overflow-x: hidden;
-}
-
-html {
-  scroll-behavior: smooth;
+  /* Android-specific fixes */
+  min-height: 100vh;
+  min-height: -webkit-fill-available;
+  position: relative;
+  /* Prevent text size adjustment on orientation change */
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  /* Fix Android Chrome address bar issues */
+  padding-top: env(safe-area-inset-top);
 }
 
 /* Performance optimization classes */
@@ -341,6 +354,23 @@ html {
   background: linear-gradient(180deg, var(--frame-gold-light) 0%, var(--frame-bronze) 100%);
 }
 
+/* Safe area utilities for mobile devices */
+.pt-safe-top {
+  padding-top: max(1rem, env(safe-area-inset-top));
+}
+
+.pb-safe-bottom {
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+}
+
+/* Android-specific viewport fixes */
+@supports (-webkit-appearance: none) {
+  body {
+    /* Additional Android Chrome fixes */
+    min-height: 100dvh;
+  }
+}
+
 /* Responsive design helpers */
 @media (max-width: 768px) {
   .museum-frame {
@@ -355,12 +385,20 @@ html {
   .paper-bg {
     background-size: 16px 16px, 32px 32px, 32px 32px;
   }
+  
+  /* Ensure title is fully visible on mobile */
+  .gallery-title {
+    padding-top: max(2rem, env(safe-area-inset-top, 2rem));
+    margin-top: 0;
+  }
 }
 
 @media (max-width: 640px) {
   .gallery-title {
     line-height: 1.2;
     letter-spacing: -0.01em;
+    padding-top: max(3rem, env(safe-area-inset-top, 3rem));
+    margin-top: 0;
   }
   
   .museum-frame {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,6 +27,14 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover'
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -46,7 +46,7 @@ export default function HeroSection({ featuredPaintings, onScrollToGallery }: He
       </ParallaxBackground>
 
       <div className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="min-h-screen flex items-center">
+        <div className="min-h-screen flex items-center pt-safe-top">
           <div className="grid lg:grid-cols-12 gap-12 items-center w-full">
             
             {/* Left Column - Text Content */}
@@ -59,7 +59,7 @@ export default function HeroSection({ featuredPaintings, onScrollToGallery }: He
                   initial={{ opacity: 0, y: 30 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.8, delay: baseDelay }}
-                  className="gallery-title text-5xl md:text-6xl lg:text-7xl text-center lg:text-left"
+                  className="gallery-title text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-center lg:text-left leading-tight pt-4 pb-2"
                 >
                   The Paintings of{' '}
                   <Link href="/about" className="relative inline-block mt-2 group">


### PR DESCRIPTION
## Summary
- Fixed Android-specific viewport jumping when entering the website
- Resolved title being half-hidden on Android devices
- Added proper viewport configuration using Next.js 15 viewport export
- Implemented safe area inset support for modern devices

## Technical Changes
- Added `viewport` export in layout.tsx with proper Android-compatible settings
- Enhanced CSS with Android-specific fixes including 100dvh support
- Added safe area utilities for devices with notches/dynamic islands
- Improved responsive title positioning with proper padding
- Prevented text size adjustment on orientation changes

## Test plan
- [x] Build succeeds without errors or warnings
- [x] Viewport configuration follows Next.js 15 best practices
- [x] Title positioning improved on mobile devices
- [x] Android-specific CSS fixes implemented
- [x] Safe area support added for modern devices

Fixes the reported Android viewport jumping and title visibility issues.

🤖 Generated with [Claude Code](https://claude.ai/code)