### PR TITLE
Randomize painting order on each page load

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,18 +2,19 @@
 
 import { useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import { alterMetzgerGallery, generateLoopedPaintings } from '@/utils/galleryData';
+import { alterMetzgerGallery, generateLoopedPaintings, shuffleArray } from '@/utils/galleryData';
 import HeroSection from '@/components/HeroSection';
 import GallerySection from '@/components/GallerySection';
 import PaintingModal from '@/components/PaintingModal';
 import { Painting } from '@/types';
 
-const allPaintings = [
+const basePaintings = [
   ...alterMetzgerGallery.paintings,
   ...generateLoopedPaintings(40)
 ];
 
 export default function Home() {
+  const [allPaintings] = useState<Painting[]>(() => shuffleArray(basePaintings));
   const [selectedPainting, setSelectedPainting] = useState<Painting | null>(null);
   const galleryRef = useRef<HTMLDivElement>(null);
 

--- a/utils/galleryData.ts
+++ b/utils/galleryData.ts
@@ -423,3 +423,12 @@ export const generateLoopedPaintings = (count: number): Painting[] => {
     };
   });
 };
+
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+};


### PR DESCRIPTION
Add Fisher-Yates shuffle utility and apply it to paintings when the
component mounts, so visitors see a different arrangement each time
they visit the gallery.

https://claude.ai/code/session_012yLhLmcq7vqteqZXmqWrKu